### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,6 @@
 {
-  "nxCloudAccessToken": "MzYwMWNmYzgtMTYwZi00MDJkLWFlYTAtZGYyN2YyMGNkNDc0fHJlYWQtd3JpdGU=",
-  "nxCloudUrl": "https://staging.nx.app",
+  "nxCloudAccessToken": "Zjc1NGVkMDItNmU2My00NWNhLWFlZDctMjdhNWE4NDdkZDE3fHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "http://localhost:4202",
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
     "build": {
@@ -8,13 +8,8 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "lint": {
-      "cache": true
-    },
-    "e2e": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    },
+    "lint": { "cache": true },
+    "e2e": { "cache": true, "inputs": ["default", "^production"] },
     "@nx/eslint:lint": {
       "cache": true,
       "inputs": [
@@ -27,15 +22,8 @@
     "@nx/jest:jest": {
       "cache": true,
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
-      "options": {
-        "passWithNoTests": true
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true
-        }
-      }
+      "options": { "passWithNoTests": true },
+      "configurations": { "ci": { "ci": true, "codeCoverage": true } }
     }
   },
   "namedInputs": {
@@ -53,11 +41,6 @@
     "sharedGlobals": []
   },
   "generators": {
-    "@nx/next": {
-      "application": {
-        "style": "css",
-        "linter": "eslint"
-      }
-    }
+    "@nx/next": { "application": { "style": "css", "linter": "eslint" } }
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/665f36a9ac14aae0aa108b0b/workspaces/665f37dafdb61a293c2fe4bf

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.